### PR TITLE
Avoid catastrophic GC in every frame.

### DIFF
--- a/FakePrototypeStuff/JoystickInputToEvents.cs
+++ b/FakePrototypeStuff/JoystickInputToEvents.cs
@@ -2,71 +2,85 @@ using UnityEngine;
 using UnityEngine.InputNew;
 
 public class JoystickInputToEvents
-	: MonoBehaviour
+    : MonoBehaviour
 {
-	#region Public Methods
+    #region Public Methods
 
-	public void Update()
-	{
-		SendButtonEvents();
-		SendAxisEvents();
-	}
+    public void Update()
+    {
+        SendButtonEvents();
+        SendAxisEvents();
+    }
 
-	#endregion
+    #endregion
 
-	#region Non-Public Methods
+    #region Non-Public Methods
 
-	// Fake gamepad has 10 axes (index 0 - 9) and 20 buttons (index 10 - 29).
-	public const int axisCount = 10;
-	public const int buttonCount = 20;
-	public const int joystickCount = 10;
-	private float[,] m_LastValues = new float[joystickCount, axisCount + buttonCount];
-	
-	private void SendAxisEvents()
-	{
-		int first = 1;
-		int last = 10;
-		for (int device = 0; device < joystickCount; device++)
-		{
-			for (int i = 0; i <= last - first; i++)
-			{
-				var value = Input.GetAxis("Analog" + (i + first) + "_Joy" + (device + 1));
-				SendEvent(device, i, value);
-			}
-		}
-	}
+    // Fake gamepad has 10 axes (index 0 - 9) and 20 buttons (index 10 - 29).
+    public const int axisCount = 10;
+    public const int buttonCount = 20;
+    public const int joystickCount = 10;
+    private float[,] m_LastValues = new float[joystickCount, axisCount + buttonCount];
+    private string[] m_AxisNames = new string[axisCount * joystickCount];
 
-	private void SendButtonEvents()
-	{
-		
-		for (int device = 0; device < joystickCount; device++)
-		{
-			int first = (int)KeyCode.Joystick1Button0 + device * 20;
-			int last = (int)KeyCode.Joystick1Button19 + device * 20;
-			
-			for (int i = 0; i <= last - first; i++)
-			{
-				if (Input.GetKeyDown((KeyCode)(i + first)))
-					SendEvent(device, axisCount + i, 1.0f);
-				if (Input.GetKeyUp((KeyCode)(i + first)))
-					SendEvent(device, axisCount + i, 0.0f);
-			}
-		}
-	}
+    private void Awake()
+    {
+        int first = 1;
+        int last = 10;
+        for (int device = 0; device < joystickCount; device++)
+        {
+            for (int i = 0; i <= last - first; i++)
+            {
+                m_AxisNames[i + device * axisCount] = ("Analog" + (i + first) + "_Joy" + (device + 1));
+            }
+        }
+    }
 
-	private void SendEvent(int deviceIndex, int controlIndex, float value)
-	{
-		if (value == m_LastValues[deviceIndex, controlIndex])
-			return;
-		m_LastValues[deviceIndex, controlIndex] = value;
-		
-		var inputEvent = InputSystem.CreateEvent<GenericControlEvent>();
-		inputEvent.deviceType = typeof(Gamepad);
-		inputEvent.deviceIndex = deviceIndex;
-		inputEvent.controlIndex = controlIndex;
-		inputEvent.value = value;
-		InputSystem.QueueEvent(inputEvent);
-	}
+    private void SendAxisEvents()
+    {
+        int first = 1;
+        int last = 10;
+        for (int device = 0; device < joystickCount; device++)
+        {
+            for (int i = 0; i <= last - first; i++)
+            {
+                var value = Input.GetAxis(m_AxisNames[i + device * axisCount]);
+                SendEvent(device, i, value);
+            }
+        }
+    }
 
-	#endregion
+    private void SendButtonEvents()
+    {
+
+        for (int device = 0; device < joystickCount; device++)
+        {
+            int first = (int)KeyCode.Joystick1Button0 + device * 20;
+            int last = (int)KeyCode.Joystick1Button19 + device * 20;
+
+            for (int i = 0; i <= last - first; i++)
+            {
+                if (Input.GetKeyDown((KeyCode)(i + first)))
+                    SendEvent(device, axisCount + i, 1.0f);
+                if (Input.GetKeyUp((KeyCode)(i + first)))
+                    SendEvent(device, axisCount + i, 0.0f);
+            }
+        }
+    }
+
+    private void SendEvent(int deviceIndex, int controlIndex, float value)
+    {
+        if (value == m_LastValues[deviceIndex, controlIndex])
+            return;
+        m_LastValues[deviceIndex, controlIndex] = value;
+
+        var inputEvent = InputSystem.CreateEvent<GenericControlEvent>();
+        inputEvent.deviceType = typeof(Gamepad);
+        inputEvent.deviceIndex = deviceIndex;
+        inputEvent.controlIndex = controlIndex;
+        inputEvent.value = value;
+        InputSystem.QueueEvent(inputEvent);
+    }
+
+    #endregion
 }

--- a/FakePrototypeStuff/KeyboardInputToEvents.cs
+++ b/FakePrototypeStuff/KeyboardInputToEvents.cs
@@ -5,33 +5,34 @@ using UnityEngine.InputNew;
 using Assets.Utilities;
 
 public class KeyboardInputToEvents
-	: MonoBehaviour
+    : MonoBehaviour
 {
-	public void Update()
-	{
-		int controlCount = EnumHelpers.GetValueCount<KeyCode>();
-		for (int i = 0; i < controlCount; i++)
-			HandleKey((KeyCode)i, (KeyCode)i);
-	}
+    private int controlCount = EnumHelpers.GetValueCount<KeyCode>();
 
-	void HandleKey(KeyCode keyCode, KeyCode keyControl)
-	{
-		if (Input.GetKeyDown(keyCode))
-			SendKeyboardEvent(keyControl, true);
-		if (Input.GetKeyUp(keyCode))
-			SendKeyboardEvent(keyControl, false);
-	}
+    public void Update()
+    {
+        for (int i = 0; i < controlCount; i++)
+            HandleKey((KeyCode)i, (KeyCode)i);
+    }
 
-	void SendKeyboardEvent(KeyCode key, bool isDown)
-	{
-		var inputEvent = InputSystem.CreateEvent<KeyboardEvent>();
+    void HandleKey(KeyCode keyCode, KeyCode keyControl)
+    {
+        if (Input.GetKeyDown(keyCode))
+            SendKeyboardEvent(keyControl, true);
+        if (Input.GetKeyUp(keyCode))
+            SendKeyboardEvent(keyControl, false);
+    }
 
-		inputEvent.deviceType = typeof(Keyboard);
-		inputEvent.deviceIndex = 0;
-		inputEvent.key = key;
-		inputEvent.isDown = isDown;
-		////TODO: modifiers
+    void SendKeyboardEvent(KeyCode key, bool isDown)
+    {
+        var inputEvent = InputSystem.CreateEvent<KeyboardEvent>();
 
-		InputSystem.QueueEvent(inputEvent);
-	}
+        inputEvent.deviceType = typeof(Keyboard);
+        inputEvent.deviceIndex = 0;
+        inputEvent.key = key;
+        inputEvent.isDown = isDown;
+        ////TODO: modifiers
+
+        InputSystem.QueueEvent(inputEvent);
+    }
 }


### PR DESCRIPTION
# Before
![before1](https://cloud.githubusercontent.com/assets/1110795/24835109/f3f9c7e4-1d32-11e7-8128-4e49075f9678.PNG)
![before2](https://cloud.githubusercontent.com/assets/1110795/24835111/f8935cf2-1d32-11e7-962a-cf1152804fee.PNG)
![before3](https://cloud.githubusercontent.com/assets/1110795/24835110/f6bf74f6-1d32-11e7-9226-b04d2009c7b9.PNG)

# After
ZeroGC and from 2x to 4x faster than before frame time.
![after](https://cloud.githubusercontent.com/assets/1110795/24835119/1b98f518-1d33-11e7-8b8a-ddc56cda3bfc.PNG)
