### PR TITLE
Exposed an external method to register new input devices

### DIFF
--- a/Input/Core/InputSystem.cs
+++ b/Input/Core/InputSystem.cs
@@ -104,6 +104,11 @@ namespace UnityEngine.InputNew
 			s_BindingListeners.Add(listener);
 		}
 
+		public static void RegisterDevice(InputDevice device)
+		{
+			s_Devices.RegisterDevice(device);
+		}
+
 		#endregion
 
 		#region Non-Public Methods


### PR DESCRIPTION
### Purpose of this PR

This exposes a function to register new input devices from code outside of the input system.  We need this to address https://github.com/Unity-Technologies/EditorVR/issues/85

### Testing status

This was previously tested with EditorVR in regards to getting a 3drudder working without modifying the input prototype.

### Technical risk

Low: Our built-in code does not use this function so it will not effect any stock EVR installations
