### PR TITLE
Bugfix for joysticktoinputevents that was causing a compile error in players

### DIFF
--- a/FakePrototypeStuff/JoystickInputToEvents.cs
+++ b/FakePrototypeStuff/JoystickInputToEvents.cs
@@ -2,7 +2,9 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.InputNew;
 
+#if UNITY_EDITOR
 [InitializeOnLoad]
+#endif
 public class JoystickInputToEvents
 	: MonoBehaviour
 {


### PR DESCRIPTION
### Purpose of this PR

JoystickToInputEvents was causing a compile error when building players - this makes sure we aren't using this tag in that scenario, where it is not invalid.

### Testing status

Tested in EVR in adventure scene and empty project, building a player.

### Technical risk

Low, where this was having an impact (builds) were not working at all previously

### Comments to reviewers
