### PR TITLE
Fix ActionMap get_isPlayingOrWillChangePlaymode

### DIFF
--- a/Input/Actions/ActionMap.cs
+++ b/Input/Actions/ActionMap.cs
@@ -21,7 +21,7 @@ namespace UnityEngine.InputNew
 		[SerializeField]
 		private List<InputAction> m_Actions = new List<InputAction>();
 		public List<InputAction> actions { get { return m_Actions; } set { m_Actions = value; } }
-		
+
 		[SerializeField]
 		private List<ControlScheme> m_ControlSchemes = new List<ControlScheme>();
 		private List<ControlScheme> m_ControlSchemeCopies; // In players or playmode we always hand out copies and retain the originals.
@@ -57,7 +57,7 @@ namespace UnityEngine.InputNew
 		private static List<ActionMap> s_ActionMapsToCleanUpAfterPlayMode = new List<ActionMap>();
 		private static bool s_IsInPlayMode;
 
-		static ActionMap()
+		void OnEnable()
 		{
 			HandlePlayModeCustomizations();
 			EditorApplication.playmodeStateChanged += HandlePlayModeCustomizations;


### PR DESCRIPTION
TODO: Fix error.
get_isPlayingOrWillChangePlaymode is not allowed to be called from a MonoBehaviour constructor,
call it in Awake or Start instead. Called from script 'ActionMap' on game object 'MenuActions'.
See "Script Serialization" page in the Unity Manual for further details.